### PR TITLE
Easy writing of greek letters

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -116,4 +116,8 @@
             { "key": "setting.julia", "operator": "equal", "operand": true }
         ]
     }
+    { 	"keys": ["escape"], 
+		"context":  [
+			{"key": "selector", "operator": "equal"}],
+		"command": "insert_greek"}
 ]

--- a/insertGreeks.py
+++ b/insertGreeks.py
@@ -1,0 +1,59 @@
+import sublime, sublime_plugin
+greeks = { 
+'a':'α',
+'b':'β',
+'g':'γ',
+'d':'δ',
+'ep':'ε',
+'z':'ζ',
+'et':'η',
+'th':'θ',
+'i':'ι',
+'k':'κ',
+'l':'λ',
+'m':'μ',
+'n':'ν',
+'x':'ξ',
+'omi':'ο',
+'pi':'π',
+'r':'ρ',
+'s':'σ',
+'t':'τ',
+'u':'υ',
+'phi':'φ',
+'c':'χ',
+'psi':'ψ',
+'ome':'ω',
+'A':'Α',
+'B':'Β',
+'G':'Γ',
+'D':'Δ',
+'Ep':'Ε',
+'Z':'Ζ',
+'Et':'Η',
+'Th':'Θ',
+'I':'Ι',
+'K':'Κ',
+'L':'Λ',
+'M':'Μ',
+'N':'Ν',
+'X':'Ξ',
+'Omi':'Ο',
+'Pi':'Π',
+'R':'Ρ',
+'S':'Σ',
+'T':'Τ',
+'U':'Υ',
+'Phi':'Φ',
+'C':'Χ',
+'Psi':'Ψ',
+'Ome':'Ω'
+}
+
+class InsertGreekCommand(sublime_plugin.TextCommand):
+	def run(self, edit, **args):
+		currsel = self.view.sel()[0]
+		currword = self.view.word(currsel)
+		k = self.view.substr(currword)
+		if (k in greeks):
+			self.view.replace(edit, currword, greeks[k])


### PR DESCRIPTION
Because Julia handles perfectly UTF-8 characters, I often find myself writing them inside equations to make them more concise. It is rather tedious using special characters, etc and I like the way how Mathematica accomplishes the thing. (By hitting escape and then writing the corresponding character.)

I added a dictionary and small macro that replicates that behavior. (Keybindings only for mac os x.)
